### PR TITLE
Add some faces for structured-haskell-mode

### DIFF
--- a/flatui-theme.el
+++ b/flatui-theme.el
@@ -431,6 +431,9 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(rainbow-delimiters-depth-10-face ((t (:foreground ,nephritis))))
    `(rainbow-delimiters-depth-11-face ((t (:foreground ,belize-hole))))
    `(rainbow-delimiters-depth-12-face ((t (:foreground ,wisteria))))
+;;;;; structured-haskell-mode
+   `(shm-current-face ((t (:background ,silver))))
+   `(shm-quarantine-face ((t (:inherit font-lock-error))))
 ;;;;; show-paren
    `(show-paren-mismatch ((t (:foreground ,sun-flower :background ,pomegranate :weight bold))))
    `(show-paren-match ((t (:foreground ,clouds :background ,alizarin :weight bold))))


### PR DESCRIPTION
This change adds support for block highlighting using [structured-haskell-mode](https://github.com/chrisdone/structured-haskell-mode).

![screenshot 2014-12-20 01 17 43](https://cloud.githubusercontent.com/assets/111265/5512605/ac954cf4-87e6-11e4-8782-6128d701d0e7.png)
